### PR TITLE
add google analytics

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -14,4 +14,14 @@
 <link rel="icon" href="/images/favicon.ico"/>
 <meta name="theme-color" content="#ffffff"/>
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-46FGEN0EY8"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-46FGEN0EY8');
+</script>
+
 <!-- end custom head snippets -->


### PR DESCRIPTION
This pull request adds Google Analytics tracking to the site by including the Google Tag Manager script and initialization code in the custom head HTML.

Analytics integration:

* Added the Google Tag Manager script and configuration for Google Analytics by updating the `_includes/head/custom.html` file.