### PR TITLE
Add blog posts collection and tweak about page

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -9,7 +9,7 @@ redirect_from:
 ---
 {% include base_path %}
 
-Machine learning and data leader with deep experience building cloud-native platforms in fintech. I drive end-to-end ML and data strategy across the credit lifecycle, accelerating teams and products by embedding AI- and LLM-powered tooling and service integrations into modeling, analytics, and product workflows. Core focus areas:
+Machine learning and data leader with deep experience building cloud-native fintech platforms. Drives end-to-end ML and data strategy across the credit lifecycle, with a core focus on short-term credit underwriting and quantitative portfolio strategy at a quarterly billion-dollar scale. Accelerates teams and products by embedding AI- and LLM-powered tooling and service integrations directly into modeling, analytics, and product workflows.
 
 - Cash-flow underwriting and short-term lending credit risk.
 - Intelligent cash-flow time series forecasting on open-banking data.

--- a/_pages/year-archive.html
+++ b/_pages/year-archive.html
@@ -1,7 +1,6 @@
 ---
 layout: archive
 permalink: /year-archive/
-title: "Blog posts"
 author_profile: true
 redirect_from:
   - /wordpress/blog-posts/

--- a/_posts/2026-04-26-cash-advance-fundamentals.md
+++ b/_posts/2026-04-26-cash-advance-fundamentals.md
@@ -1,0 +1,22 @@
+---
+title: 'Cash Advance Money Dynamics 💸'
+date: 2026-04-26
+published: false
+permalink: /posts/2026/04/welcome/
+excerpt: "A first-principles look at cash advances: just credit amount, term, and risk premium under shiny branding."
+tags:
+  - intro
+---
+## Cash Advance Foundamental
+
+When you hear "cash advance," your brain probably pictures a magical money fairy dropping a crisp hundred-dollar bill into your bank account right before payday. It sounds modern, fast, and maybe even a little glamorous if the app is shiny enough. But if we strip away the marketing jargon and look at it from a "first principles" perspective, what actually *is* a cash advance?
+
+It’s just a traditional financial product wearing a trench coat. At its core, a cash advance is completely identical to any classic credit product. It is defined by three brutally simple variables. Let's break them down:
+
+* **Credit Amount:** Exactly how much cash are they sliding across the table to you?
+* **Term/Duration:** When does the piper demand to be paid? Next week? Next payday?
+* **Risk Premium:** This is your interest, your flat fees, or your "convenience" charges. It's simply the price you pay for renting their money because platform are taking a risk on you.
+
+## The Bottom Line
+
+So, what about all the other cool stuff? The slick user interfaces, the gamified progress bars, the cheerful push notifications, and the "instant transfer" branding? That is just sugar coating with different flavors. But whether it tastes like strawberry or vanilla, under the hood, you are still just borrowing a set amount of money, for a set amount of time, for a set fee.


### PR DESCRIPTION
## Summary
- Introduce `_posts/` with first post (hidden via `published: false`)
- Drop "Blog posts" page title from year-archive
- Light copy edit to about.md intro

## Test plan
- [x] Run `bundle exec jekyll serve -l -H localhost` and confirm `/year-archive/` renders without the "Blog posts" heading
- [x] Confirm `/posts/2026/04/welcome/` 404s while `published: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)